### PR TITLE
change deprecated configuration option for syntax highlighting

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -28,7 +28,7 @@ baseurl: ''
 permalink: none
 
 # Syntax highlighting
-pygments: true
+highlighter: pygments
 
 # Since these are pages, it doesn't really matter
 future: true


### PR DESCRIPTION
Remove deprecation warning message when running newer Jekyll versions (see https://github.com/jekyll/jekyll-help/issues/48)
