### PR TITLE
Add disqus support

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -2,6 +2,9 @@
 title: 'jekyll-docs-template'
 subtitle: 'Painless documentation for your projects'
 
+# if you wish to integrate disqus on pages set your shortname here
+disqus_shortname: ''
+
 # Enable/show navigation. There are there options:
 #   0 - always hide
 #   1 - always show

--- a/_includes/disqus.html
+++ b/_includes/disqus.html
@@ -1,0 +1,13 @@
+<div id="disqus_thread"></div>
+<script type="text/javascript">
+    /* * * CONFIGURATION VARIABLES: EDIT BEFORE PASTING INTO YOUR WEBPAGE * * */
+    var disqus_shortname = '{{ site.disqus_shortname }}'; // required: replace example with your forum shortname
+
+    /* * * DON'T EDIT BELOW THIS LINE * * */
+    (function() {
+        var dsq = document.createElement('script'); dsq.type = 'text/javascript'; dsq.async = true;
+        dsq.src = '//' + disqus_shortname + '.disqus.com/embed.js';
+        (document.getElementsByTagName('head')[0] || document.getElementsByTagName('body')[0]).appendChild(dsq);
+    })();
+</script>
+<noscript>Please enable JavaScript to view the <a href="https://disqus.com/?ref_noscript">comments powered by Disqus.</a></noscript>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -38,6 +38,21 @@
                 {% endif %}
             </div>
 
+            {% if page.disqus == 1 %}
+            <div class=row-fluid>
+              {% if site.navigation == 1 or post_count > 0 %}
+                <div id=navigation class=span2></div>
+                <div id=disqus class=span10>
+                    {% include disqus.html %}
+                </div>
+              {% else %}
+                <div id=disqus class=span12>
+                    {% include disqus.html %}
+                </div>
+              {% endif %}
+            </div>
+            {% endif %}
+
             <div class=row-fluid>
                 <div id=footer class=span12>
                     {% include footer.html %}


### PR DESCRIPTION
This allows people to enable disqus on pages based on setting setting a disqus shortname in the _config.yaml and then on a per page basis setting ```disqus: 1```