### PR TITLE
GitHub friendly symlinks

### DIFF
--- a/bin/jekyll-page
+++ b/bin/jekyll-page
@@ -97,7 +97,7 @@ File.open(filepath, 'w') do |file|
     file.puts content
 end
 
-File.symlink(File.absolute_path(filepath), symlink)
+File.symlink("../_posts/#{today}-#{filename}.md", symlink)
 
 if options[:edit]
     if not ENV['EDITOR']


### PR DESCRIPTION
Allow symlinks for _pages to work on GitHub pages. Relative path instead of absolute path.