### PR TITLE
CSS for codeblock, change configuration to rouge and kramdown

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -34,7 +34,7 @@ baseurl: ''
 permalink: none
 
 # Syntax highlighting
-highlighter: pygments
+highlighter: rogue
 
 # Since these are pages, it doesn't really matter
 future: true
@@ -42,8 +42,8 @@ future: true
 # Exclude non-site files
 exclude: ['bin', 'README.md']
 
-# Use the redcarpet Markdown renderer
-markdown: redcarpet
+# Use the kramdown Markdown renderer
+markdown: kramdown
 redcarpet:
     extensions: [
         'no_intra_emphasis',

--- a/css/main.css
+++ b/css/main.css
@@ -3,11 +3,15 @@ body {
     text-shadow: 0 1px 1px rgba(255, 255, 255, 0.7);
 }
 
-pre, code {
+pre, code, pre code {
     border: none;
     border-radius: 0;
     background-color: #f9f9f9;
     font-size: 0.85em;
+}
+
+.highlight {
+    background-color: #f9f9f9;
 }
 
 pre {

--- a/css/main.css
+++ b/css/main.css
@@ -81,3 +81,14 @@ body.rtl .row-fluid [class*="span"]:first-child {
 body.rtl ul, body.rtl ol {
     margin: 0 25px 10px 0;
 }
+
+table {
+  margin-bottom: 1rem;
+  border: 1px solid #e5e5e5;
+  border-collapse: collapse;
+}
+
+td, th {
+  padding: .25rem .5rem;
+  border: 1px solid #e5e5e5;
+}


### PR DESCRIPTION
- change markdown to Kramdown and highlighter to rouge according to [this post](https://github.com/blog/2100-github-pages-now-faster-and-simpler-with-jekyll-3-0)
- css for code block highlight (backtick-style fenced code blocks)